### PR TITLE
Bug: Fix prop type checking for errorTextStyle in FormInputHoc.js.

### DIFF
--- a/src/formInputs/FormInputHOC.js
+++ b/src/formInputs/FormInputHOC.js
@@ -38,7 +38,7 @@ const propTypes = {
   invalidInputStyle: Text.propTypes.style,
 
   errorContainerStyle: ViewPropTypes.style,
-  errorTextStyle: ViewPropTypes.style,
+  errorTextStyle: Text.propTypes.style,
   errorText: PropTypes.string,
 
   validator: PropTypes.func,


### PR DESCRIPTION
Fix the issue: https://github.com/lsps9150414/react-native-ui-toolbox/issues/8